### PR TITLE
Add division module with basic properties

### DIFF
--- a/Data/Binary/Division.agda
+++ b/Data/Binary/Division.agda
@@ -1,0 +1,17 @@
+module Data.Binary.Division where
+
+open import Data.Binary.Definition
+open import Data.Binary.Conversion
+import Agda.Builtin.Nat as ℕ
+
+-- integer division on natural numbers
+-- dividing by zero yields zero
+
+div : ℕ.Nat → ℕ.Nat → ℕ.Nat
+div n ℕ.zero    = ℕ.zero
+div n (ℕ.suc m) = ℕ.div-helper ℕ.zero m n m
+
+infixl 7 _÷_
+_÷_ : 𝔹 → 𝔹 → 𝔹
+xs ÷ ys = ⟦ div ⟦ xs ⇓⟧ ⟦ ys ⇓⟧ ⇑⟧
+

--- a/Data/Binary/Properties.agda
+++ b/Data/Binary/Properties.agda
@@ -8,6 +8,8 @@ open import Data.Binary.Properties.Multiplication public
   using (*-cong)
 open import Data.Binary.Properties.Subtraction public
   using (-‿cong)
+open import Data.Binary.Properties.Division public
+  using (÷-cong)
 open import Data.Binary.Properties.Conversion public
   using (fast-correct)
 open import Data.Binary.Properties.Isomorphism public

--- a/Data/Binary/Properties/Division.agda
+++ b/Data/Binary/Properties/Division.agda
@@ -1,0 +1,26 @@
+{-# OPTIONS --cubical #-}
+
+module Data.Binary.Properties.Division where
+
+open import Data.Binary.Definition
+open import Data.Binary.Conversion
+open import Data.Binary.Division
+import Agda.Builtin.Nat as ℕ
+
+open import Data.Binary.Properties.Isomorphism
+open import Data.Binary.Properties.Helpers
+open import Data.Binary.Helpers
+
+0÷ : ∀ ys → 0ᵇ ÷ ys ≡ 0ᵇ
+0÷ 0ᵇ      = refl
+0÷ (1ᵇ ys) = refl
+0÷ (2ᵇ ys) = refl
+
+÷0 : ∀ xs → xs ÷ 0ᵇ ≡ 0ᵇ
+÷0 0ᵇ      = refl
+÷0 (1ᵇ xs) = refl
+÷0 (2ᵇ xs) = refl
+
+÷-cong : ∀ xs ys → ⟦ xs ÷ ys ⇓⟧ ≡ div ⟦ xs ⇓⟧ ⟦ ys ⇓⟧
+÷-cong xs ys = ℕ→𝔹→ℕ (div ⟦ xs ⇓⟧ ⟦ ys ⇓⟧)
+


### PR DESCRIPTION
## Summary
- implement `Data.Binary.Division` with a simple definition of division using `div-helper`
- prove properties of division in new `Data.Binary.Properties.Division`
- re-export division proofs from `Data.Binary.Properties`

## Testing
- `scripts/check-all.sh`

------
https://chatgpt.com/codex/tasks/task_e_68738d3bb1f4832f92932a08d6e0ac4e